### PR TITLE
make room for floppy drives

### DIFF
--- a/SOURCES/kernel/MOSDDINT.ASM
+++ b/SOURCES/kernel/MOSDDINT.ASM
@@ -871,7 +871,7 @@ mosbd1b:
 mosbd2:
 	pop	es			; address of bdb
 	push	ax			; save error code
-	mov	al,1
+	mov	ah,1
 	mov	al,'B'
 	call	mosliman		; call mosliman
 	pop	ax

--- a/SOURCES/kernel/MOSINIT2.ASM
+++ b/SOURCES/kernel/MOSINIT2.ASM
@@ -4091,7 +4091,7 @@ no286a:
 	mov	[tcbcdbpf],0		; clear pointer to cdb
 	mov	[tcbcdbpc],0		; clear pointer to cdb
 	mov	[tcbndriv],0		; clear # of drives
-	mov	[scbdrivs],0		; clear any count of drives for re-init
+	mov	[scbdrivs],2		; clear any count of drives for re-init (always make room for A: and B: floppies)
 	mov	[scbbdbpf],0		; clear pointer to 1st block device
 	mov	[scbbdbpl],0		; clear pointer to last block device
 	mov	[scbgfbpf],0		; clear any active gfbs


### PR DESCRIPTION
This is supposed to fix erroneous assigning a: to a hard drive when no floppy drives are present